### PR TITLE
[음식확인 뷰, 영양점수 뷰, 히스토리 뷰] 화면 레이아웃 수정

### DIFF
--- a/kini/kini/Color.xcassets/gray010.colorset/Contents.json
+++ b/kini/kini/Color.xcassets/gray010.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0.184",
+          "green" : "0.184",
+          "red" : "0.184"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0.184",
+          "green" : "0.184",
+          "red" : "0.184"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/kini/kini/Color.xcassets/gray020.colorset/Contents.json
+++ b/kini/kini/Color.xcassets/gray020.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0.263",
+          "green" : "0.235",
+          "red" : "0.235"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0.263",
+          "green" : "0.235",
+          "red" : "0.235"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/kini/kini/Color.xcassets/gray030.colorset/Contents.json
+++ b/kini/kini/Color.xcassets/gray030.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.753",
+          "green" : "0.753",
+          "red" : "0.753"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.753",
+          "green" : "0.753",
+          "red" : "0.753"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/kini/kini/ColorExtension.swift
+++ b/kini/kini/ColorExtension.swift
@@ -9,10 +9,13 @@ import Foundation
 import SwiftUI
 
 extension Color {
-    static let yellow010 = Color("yellow010")   // colorBackground
-    static let yellow020 = Color("yellow020")   // colorPre
-    static let yellow030 = Color("yellow030")   // colorPro
-    static let navy = Color("navy") // colorNavy
+    static let yellow010 = Color("yellow010")   // Background
+    static let yellow020 = Color("yellow020")   // PrimaryButton
+    static let yellow030 = Color("yellow030")   // SecondaryButton
+    static let navy = Color("navy") // Text
     static let yellowGreen = Color("yellowGreen")
     static let shadow = Color("shadow") // colorShadow
+    static let gray010 = Color("gray010")   // PopupView Background Blur
+    static let gray020 = Color("gray020")   // HistoryView -> Nutrition Type Text -> TextModifier.XXSRegularGrayTextModifier
+    static let gray030 = Color("gray030")   // border
 }

--- a/kini/kini/FeedBackView.swift
+++ b/kini/kini/FeedBackView.swift
@@ -9,14 +9,6 @@ import SwiftUI
 
 struct FeedBackView: View {
     
-    // Color Extension List
-    let colorLightGray = Color(red: 249/255, green: 249/255, blue: 249/255) // Star Score
-    let colorBorder = Color(red: 192/255, green: 192/255, blue: 192/255)    // NavigationBar Border
-    let colorTextGray = Color(red: 130/255, green: 130/255, blue: 130/255, opacity: 85/100)
-    let colorGray = Color(red: 60/255, green: 60/255, blue: 67/255, opacity: 60/100)    // Nutrition Type Text
-    let colorBlur = Color(red: 47/255, green: 47/255, blue: 47/255, opacity: 30/100)
-    let colorShadow = Color(red: 153/255, green: 123/255, blue: 52/255, opacity: 40/100)    // Shadow Color
-    
     var selectedCharacter = "gardian_carrot"  // 선택한 캐릭터 이미지
     
     @State private var message: [String] = ["", "", "", "", ""]
@@ -43,7 +35,7 @@ struct FeedBackView: View {
             
             // MARK: NavigationBar
             Rectangle() // NavagationBar
-                .stroke(colorBorder, lineWidth: 1)
+                .stroke(Color.gray030, lineWidth: 1)
                 .background(.white)
                 .frame(width: .infinity, height: 103)
                 .padding(.bottom, 741)
@@ -52,7 +44,6 @@ struct FeedBackView: View {
                         Image(systemName: "chevron.left")    // Navigation BackButton
                             .frame(width: 15, height: 23)
                             .foregroundColor(Color.navy)
-//                                    .padding(EdgeInsets(top: 64, leading: 24, bottom: 757, trailing: 351))
                             .padding(.leading, 24)
                         
                         CharacterThumbnail(characterThumbnail: selectedCharacter, thumbnailWidth: 32, thumbnailHeight: 32)
@@ -60,12 +51,10 @@ struct FeedBackView: View {
                         
                         VStack(alignment: .leading) {    // CharacterName - CharacterMessage
                             Text("식사 친구 끼니")
-                                .foregroundColor(Color.navy)
-                                .font(.system(size: 16))
+                                .modifier(MSemiboldNavyTextModifier())
                             
                             Text("오늘도 건강하고 든든한 하루!")
-                                .foregroundColor(colorTextGray)
-                                .font(.system(size: 13))
+                                .modifier(XSRegularGrayTextModifier())
                         }   // ~VStack
                         .padding(.leading, 10)
 //                                .padding(.trailing, 139)  // 폰트 문제로 sketch 기준 수치 입력 시 text 짤림
@@ -148,7 +137,7 @@ struct FeedBackView: View {
             .padding(.top, 103) // NavigationBar 영역
             .padding(.top, 13)  // NavigationBar과의 padding
             
-            // MARK: NavigationButto
+            // MARK: NavigationButton
             // 버튼 '다음'
             Button(count == 5 ? "끼나와의 대화 마치기" : "다음"){
                 if count == 5 {
@@ -204,9 +193,8 @@ struct ChatLogKini: View {
     var body: some View {
         VStack {
             Text(message)
+                .modifier(XXSRegularNavyTextModifier())
                 .multilineTextAlignment(.leading)
-                .font(.system(size: 12))
-                .foregroundColor(Color.navy)
                 .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
                 .background(.white)
                 .cornerRadius(15)
@@ -261,9 +249,8 @@ struct ChatLogUser: View {
     var body: some View {
         VStack {
             Text(message)
+                .modifier(XXSRegularNavyTextModifier())
                 .multilineTextAlignment(.leading)
-                .font(.system(size: 12))
-                .foregroundColor(Color.navy)
                 .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
                 .background(Color.yellow030)
                 .cornerRadius(15)

--- a/kini/kini/FoodCheckView.swift
+++ b/kini/kini/FoodCheckView.swift
@@ -16,14 +16,6 @@ struct FoodCheckView: View {
     var mealTime: String = "아침" // !Sample!
     
     // Color Extension List
-    let colorBackground = Color(red: 255/255, green: 246/255, blue: 231/255)
-    let colorNavy = Color(red: 34/255, green: 49/255, blue: 116/255)    // Font, Frame Color
-    let colorLightGray = Color(red: 249/255, green: 249/255, blue: 249/255) // Star Score
-    let colorGray = Color(red: 60/255, green: 60/255, blue: 67/255, opacity: 60/100)    // Nutrition Type Text
-    let colorBlur = Color(red: 47/255, green: 47/255, blue: 47/255, opacity: 30/100)
-    let colorShadow = Color(red: 153/255, green: 123/255, blue: 52/255, opacity: 40/100)    // Shadow Color
-    let colorPre = Color(red: 251/255, green: 227/255, blue: 170/255)
-    let colorPro = Color(red: 251/255, green: 192/255, blue: 54/255)
     
     // MARK: for ReportView
     var nutrition1: [String] = ["탄수화물", "단백질", "지방"]
@@ -34,40 +26,24 @@ struct FoodCheckView: View {
     
     var body: some View {
         ZStack {    // Navigation Button - (Photo - Menu)
-            colorBackground.ignoresSafeArea()
+            Color.yellow010.ignoresSafeArea()
             VStack {    // Navigation Button
                 HStack {    // 버튼 '다시 찍을래요' - 버튼 '점수를 알려주세요'
                     // 버튼 '다시 찍을래요'
-                    Button(action: {    // action
-
-                    }) {    // label
-                        RoundedRectangle(cornerRadius: 15)
-                            .frame(width: 170, height: 50)
-                            .foregroundColor(colorPre)
-                            .shadow(color: colorShadow,radius: 6, x: 0, y: 4)
-                            .overlay {
-                                Text("다시 찍을래요")
-                                    .foregroundColor(colorNavy)
-                                    .font(.system(size: 17, weight: .semibold))
-                            }
+                    Button ("다시 찍을래요") {
+                        
                     }
+                    .modifier(ShortButtonDisabledModifier())
+                    .shadow(color: Color.shadow,radius: 6, x: 0, y: 4)
 
                     Spacer().frame(width: 13)   // 버튼 사이 여백
 
                     // 버튼 '점수를 알려주세요'
-                    Button(action: {    // action    // Popup Button
-                        self.shouldShowPopup = true
-                    }) {    // label
-                        RoundedRectangle(cornerRadius: 15)
-                            .frame(width: 170, height: 50)
-                            .foregroundColor(colorPro)
-                            .shadow(color: colorShadow,radius: 6, x: 0, y: 4)
-                            .overlay {
-                                Text("점수를 알려주세요")
-                                    .foregroundColor(colorNavy)
-                                    .font(.system(size: 17, weight: .semibold))
-                            }
-                    }   // ~label
+                    Button ("점수를 알려주세요") {
+                        
+                    }
+                    .modifier(ShortLongButtonAbledModifier())
+                    .shadow(color: Color.shadow,radius: 6, x: 0, y: 4)
                 }   // ~HStack
                 .padding(.top, 748)
                 .padding(.bottom, 46)
@@ -77,15 +53,14 @@ struct FoodCheckView: View {
             
             VStack(spacing: 0) {    // Date - Photo - Menu
                 Text("\(todayDate)")  // date
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundColor(colorNavy)
+                    .modifier(XXLBoldNavyTextModifier())
                     .padding(.top, 62)
                 
                 // Photo
                 Circle()    // Phote Frame
                     .frame(width: 301, height: 301)
-                    .foregroundColor(colorNavy)
-                    .shadow(color: colorShadow, radius: 6, x: 0, y: 4)
+                    .foregroundColor(Color.navy)
+                    .shadow(color: Color.shadow, radius: 6, x: 0, y: 4)
                     .overlay {
                         Image(systemName: "circle.fill")    // Photo -> !test!
                             .resizable()
@@ -98,26 +73,27 @@ struct FoodCheckView: View {
                 Rectangle() // Background
                     .cornerRadius(15)
                     .foregroundColor(.white)
-                    .shadow(color: colorShadow, radius: 6, x: 0, y: 4)
+                    .shadow(color: Color.shadow, radius: 6, x: 0, y: 4)
                     .frame(width: 350, height: 270)
                     .overlay {  // Menu (Title - Line - List)
                         VStack(spacing: 0) {    // Menu // spacing: 0 -> 컴포넌트 간 기본 spacing = 0
                             Text("\(userName)의 오늘의 \(mealTime) 메뉴")  // Menu Title
-                                .font(.system(size: 28))
-                                .foregroundColor(colorNavy)
+                                .modifier(XXXLBoldNavyTextModifier())
+                                .padding(.top, 20)
                             
                             Rectangle() // line
                                 .frame(width: 300.82, height: 1)
-                                .foregroundColor(colorNavy)
+                                .foregroundColor(Color.navy)
                                 .padding(.top, 6.5)
                                 .padding(.bottom, 32.5)
                             
                             ForEach(0..<6) { menuIndex in   // Menu List
                                 Text("Menu \(menuIndex+1)")
-                                    .foregroundColor(colorNavy)
-                                    .font(.system(size: 15))
+                                    .modifier(SRegularNavyTextModifier())
                                     .padding(.top, 8)
                             }   // ~ForEach
+                            
+                            Spacer().frame(height: 27)
                         }   // ~VStack
                     }   // ~overlay(Menu)
                     .padding(.top, 24)
@@ -127,7 +103,7 @@ struct FoodCheckView: View {
             }   // ~VStack
             
             .popup(isPresented: $shouldShowPopup) {
-                colorBlur
+                Color.gray010
                     .blur(radius: 2)
                     .animation(.easeInOut)
                     .ignoresSafeArea()

--- a/kini/kini/HistoryView.swift
+++ b/kini/kini/HistoryView.swift
@@ -14,14 +14,17 @@ struct HistoryView: View {
     let userName: String = "니코" // !Sample!
     var mealTime: String = "아침" // !Sample!
     
+    // Image Assets
+//    let star1: String = "star_01"
+//    let star2: String = "star_02"
+//    let star3: String = "star_03"
+//    let grape1: String = "grape_01"
+//    let grape2: String = "grape_02"
+//    let grape3: String = "grape_03"
+//    let grape4: String = "grape_04"
+    
     // Color Extension List
-    let colorBackground = Color(red: 255/255, green: 246/255, blue: 231/255)
-    let colorNavy = Color(red: 34/255, green: 49/255, blue: 116/255)    // Font, Frame Color
-    let colorLightGray = Color(red: 249/255, green: 249/255, blue: 249/255) // Star Score
-    let colorGray = Color(red: 60/255, green: 60/255, blue: 67/255, opacity: 60/100)    // Nutrition Type Text
-    let colorShadow = Color(red: 153/255, green: 123/255, blue: 52/255, opacity: 40/100)    // Shadow Color
-    let colorPre = Color(red: 251/255, green: 227/255, blue: 170/255)
-    let colorPro = Color(red: 251/255, green: 192/255, blue: 54/255)
+    let colorLightGray = Color(red: 249/255, green: 249/255, blue: 249/255) // Star Background
     let nutritionColor: [Color] = [Color(red: 254/255, green: 226/255, blue: 125/255),
                                    Color(red: 237/255, green: 175/255, blue: 199/255),
                                    Color(red: 190/255, green: 210/255, blue: 125/255),
@@ -32,21 +35,22 @@ struct HistoryView: View {
     let time: [String] = ["아침", "점심", "저녁"]
     let nutritionType: [String] = ["곡류", "고기, 생선, 달걀, 콩류", "채소류",
                                    "과일류", "우유, 유제품류", "유지, 당류"]
+    let starGrade: [String] = ["star_01", "star_02", "star_03"]   // 아침 점심 저녁 별점  // !Sample!
+    let grapeGrade: [String] = ["grape_01", "grape_02", "grape_03", "grape_04"] // 포도 등급
     
     var body: some View {
         ZStack {
-            colorBackground.ignoresSafeArea()
+            Color.yellow010.ignoresSafeArea()
             
             Text("나의 끼니 기록")    // Navigation Title
-                .font(.system(size: 22, weight: .bold))
-                .foregroundColor(colorNavy)
+                .modifier(XXLBoldNavyTextModifier())
                 .padding(.top, 62)
                 .padding(.bottom, 754)
             
             Image(systemName: "chevron.left")    // Navigation BackButton
 //                .font(.system(size: 24)
                 .frame(width: 15, height: 23)
-                .foregroundColor(colorNavy)
+                .foregroundColor(Color.navy)
                 .padding(EdgeInsets(top: 64, leading: 24, bottom: 757, trailing: 351))
             
             VStack {
@@ -54,38 +58,37 @@ struct HistoryView: View {
                     Rectangle() // Background
                         .cornerRadius(15)
                         .foregroundColor(.white)
-                        .shadow(color: colorShadow, radius: 4, x: 0, y: 2)
+                        .shadow(color: Color.shadow, radius: 4, x: 0, y: 2)
                         .frame(width: 350, height: 254)
                         .padding(.top, 140)
                     
                     VStack(spacing: 0) {    // Date - Grade - Chart
                         Text(historyDate)  // Date
-                            .font(.system(size: 12))
-                            .foregroundColor(colorNavy)
+                            .modifier(XXSRegularNavyTextModifier())
                             .padding(.top, 50)
                         
                         Text("오늘의 영양점수")
-                            .font(.system(size: 17, weight: .semibold))
-                            .foregroundColor(colorNavy)
+                            .modifier(LSemiboldNavyTextModifier())
                             .padding(.top, 5)
                         
                         HStack {    // Grade
-                            ForEach(time, id: \.self) { time in
+                            ForEach (0..<3) { index in
                                 Rectangle()
                                     .cornerRadius(10)
                                     .frame(width: 106.07, height: 135)
                                     .foregroundColor(colorLightGray)
                                     .overlay {
                                         VStack(spacing: 0) {    // Grade Image - Time
-                                            Image(systemName: "star.square")   // Grade Image
+                                            // 별점 계산 결과 별 Image 다르게
+                                            
+                                            Image(starGrade[index])   // Grade Image
                                                 .resizable()
                                                 .scaledToFit()
                                                 .frame(width: 87, height: 84)
                                                 .padding(.top, 8)
                                             
-                                            Text(time)
-                                                .font(.system(size: 13, weight: .semibold))
-                                                .foregroundColor(colorNavy)
+                                            Text(time[index])
+                                                .modifier(XSSemiboldNavyTextModifier())
                                                 .padding(.top, 16)
                                                 .padding(.bottom, 9)
                                         }
@@ -101,18 +104,17 @@ struct HistoryView: View {
                     Rectangle() // Background
                         .cornerRadius(15)
                         .foregroundColor(.white)
-                        .shadow(color: colorShadow, radius: 4, x: 0, y: 2)
+                        .shadow(color: Color.shadow, radius: 4, x: 0, y: 2)
                         .frame(width: 350, height: 387)
                         .padding(.top, 17)
                     
                     VStack {
                         Text("오늘의 영양차트")
-                            .font(.system(size: 17, weight: .semibold))
-                            .foregroundColor(colorNavy)
+                            .modifier(LSemiboldNavyTextModifier())
                             .padding(.top, 15)
                         
                         Circle() // Chart
-                            .foregroundColor(colorNavy)
+                            .foregroundColor(Color.navy)
                             .frame(width: 254, height: 254)
                             .padding(.bottom, 14)
                         
@@ -124,8 +126,7 @@ struct HistoryView: View {
                                     .padding(.trailing, 4)
                                 
                                 Text(nutritionType[$0]) // Nutrition Type
-                                    .font(.system(size: 12))
-                                    .foregroundColor(colorGray)
+                                    .modifier(XXSRegularGrayTextModifier())
                                     .frame(minWidth: 32, alignment: .leading)
                                     .padding(.trailing, 8)
                             }
@@ -141,8 +142,7 @@ struct HistoryView: View {
                                     .padding(.trailing, 4)
                                 
                                 Text(nutritionType[$0]) // Nutrition Type
-                                    .font(.system(size: 12))
-                                    .foregroundColor(colorGray)
+                                    .modifier(XXSRegularGrayTextModifier())
                                     .frame(minWidth: 32, alignment: .leading)
                                     .padding(.trailing, 8)
                             }
@@ -159,10 +159,11 @@ struct HistoryView: View {
                 Image(systemName: "arrowtriangle.left.fill") // prev
                     .resizable()
                     .aspectRatio(CGSize(width: 0.75, height: 1), contentMode: .fit)
+                    .foregroundColor(Color.navy)
                     .frame(width: 20, height: 15)
                     .padding(.trailing, 60)
                 
-                Image(systemName: "face.smiling.inverse")    // Sticker
+                Image(grapeGrade[2])    // Sticker
                     .resizable()
                     .scaledToFit()
                     .frame(width: 80)
@@ -171,6 +172,7 @@ struct HistoryView: View {
                 Image(systemName: "arrowtriangle.right.fill") // next
                     .resizable()
                     .aspectRatio(CGSize(width: 0.75, height: 1), contentMode: .fit)
+                    .foregroundColor(Color.navy)
                     .frame(width: 20, height: 15)
                     .padding(.leading, 60)
             }   // ~HStack

--- a/kini/kini/ReportView.swift
+++ b/kini/kini/ReportView.swift
@@ -11,60 +11,52 @@ import PopupView
 struct ReportView: View {
     
     // Color Extension List
-    let colorBackground = Color(red: 255/255, green: 246/255, blue: 231/255)
-    let colorNavy = Color(red: 34/255, green: 49/255, blue: 116/255)    // Font, Frame Color
     let colorLightPumpkin = Color(red: 255/255, green: 246/255, blue: 231/255)
-    let colorLightGray = Color(red: 249/255, green: 249/255, blue: 249/255) // Star Score
-    let colorGray = Color(red: 60/255, green: 60/255, blue: 67/255, opacity: 60/100)    // Nutrition Type Text
-    let colorShadow = Color(red: 153/255, green: 123/255, blue: 52/255, opacity: 40/100)    // Shadow Color
-    let colorBlur = Color(red: 47/255, green: 47/255, blue: 47/255, opacity: 30/100)
-    let colorPre = Color(red: 251/255, green: 227/255, blue: 170/255)
-    let colorPro = Color(red: 251/255, green: 192/255, blue: 54/255)
     
     // MARK: for ReportView
-    var nutrition1: [String] = ["탄수화물", "단백질", "지방"]
-    var nutrition2: [String] = ["당", "열량", "콜레스테롤"]
+    var nutrition: [String] = ["탄수화물", "단백질", "지방", "당", "열량", "콜레스테롤"]
     
     var grade: String = "훌륭해요!"  // !Sample"
     
     @State var shouldShowPopup : Bool = false   // Popup 여부
+    var scoreStar : [Bool] = [true, true, false]    // !Sample 별점!
+    var scoreGrade : [String] = ["grade_01", "grade_02", "grade_02",
+                                 "grade_03", "grade_01", "grade_01"]    // !Sample 포도 등급!
     
     var body: some View {
             ZStack {
-//                colorBlur
-//                    .blur(radius: 2)
-//                    .animation(.easeInOut, value: 0.5)
-//                    .ignoresSafeArea()
+                Color.gray010
+                    .blur(radius: 2)
+                    .animation(.easeInOut, value: 0.5)
+                    .ignoresSafeArea()
                 
                 Rectangle()  // Popup
                     .cornerRadius(15)
                     .frame(width: 350, height: 418)
                     .foregroundColor(.white)
+                    .shadow(color: Color.shadow, radius: 6, x: 0, y: 4)
                     .overlay {
                         VStack(spacing: 0) {    //Grade - Nutrition - Navigation Button
                             Text(grade)   // Grade
-                                .font(.system(size: 28))
-                                .foregroundColor(colorNavy)
+                                .modifier(XXXLBoldNavyTextModifier())
                                 .padding(.top, 55)
 
-                            HStack(spacing: 0) {    // Nutrition 1/2
-                                ForEach(nutrition1, id: \.self) { nutrition in   // nutrition1
+                            HStack(spacing: 7.26) {    // Nutrition 1/2
+                                ForEach(0..<3) { index in   // nutrition1
                                     RoundedRectangle(cornerRadius: 10)  //  // Nutrition Frame
                                         .frame(width: 102.37, height: 107.99)
                                         .foregroundColor(colorLightPumpkin)
-                                        .padding(.horizontal, 5)
                                         .overlay {
                                             VStack(spacing: 0) {
-                                                Image(systemName: "face.smiling.inverse")  // Nutrition Image
+                                                Image(scoreGrade[index])  // Nutrition Image
                                                     .resizable()
                                                     .scaledToFit()
                                                     .clipShape(Circle())
                                                     .frame(width: 70, height: 70)
                                                     .padding(.top, 7)
                                                 
-                                                Text(nutrition) // Nutrition Title
-                                                    .font(.system(size: 12))
-                                                    .foregroundColor(colorNavy)
+                                                Text(nutrition[index]) // Nutrition Title
+                                                    .modifier(XXSRegularNavyTextModifier())
                                                     .padding(.top, 10)
                                                     .padding(.bottom, 6.99)
                                             }   // ~VStack
@@ -73,24 +65,22 @@ struct ReportView: View {
                             }   // ~HStack
                             .padding(.top, 12)
 
-                            HStack(spacing: 0) {    // Nutrition 2/2
-                                ForEach(nutrition1, id: \.self) { nutrition in   // nutrition2
+                            HStack(spacing: 7.26) {    // Nutrition 2/2
+                                ForEach(3..<6) { index in   // nutrition2
                                     RoundedRectangle(cornerRadius: 10)  //  // Nutrition Frame
                                         .frame(width: 102.37, height: 107.99)
                                         .foregroundColor(colorLightPumpkin)
-                                        .padding(.horizontal, 5)
                                         .overlay {
                                             VStack(spacing: 0) {
-                                                Image(systemName: "face.smiling.inverse")  // Nutrition Image
+                                                Image(scoreGrade[index])  // Nutrition Image
                                                     .resizable()
                                                     .scaledToFit()
                                                     .clipShape(Circle())
                                                     .frame(width: 70, height: 70)
                                                     .padding(.top, 7)
                                                 
-                                                Text(nutrition) // Nutrition Title
-                                                    .font(.system(size: 12))
-                                                    .foregroundColor(colorNavy)
+                                                Text(nutrition[index]) // Nutrition Title
+                                                    .modifier(XXSRegularNavyTextModifier())
                                                     .padding(.top, 10)
                                                     .padding(.bottom, 6.99)
                                             }   // ~VStack
@@ -100,41 +90,36 @@ struct ReportView: View {
                             .padding(.top, 7.01)
 
                             // Navigation Button -> 4.1 FeedBackView
-                            Button(action: {    // action
-
-                            }) {    // label
-                                RoundedRectangle(cornerRadius: 15)
-                                    .foregroundColor(colorPro)
-                                    .shadow(color: colorShadow,radius: 4, x: 0, y: 2)
-                                    .frame(width: 322, height: 46)
-                                    .overlay {
-                                        Text("식사친구 끼니의 메세지가 도착했어요")
-                                            .foregroundColor(.white)
-                                    }
-                                    .padding(.top, 28.01)
-                                    .padding(.bottom, 19)
+                            Button("식사친구 끼니의 메세지가 도착했어요!") {
+                                
                             }
-                            .padding(.top, 7.01)
+                            .modifier(PopUpButtonModifier())
+                            .shadow(color: Color.shadow, radius: 6, x: 0, y: 4)
+                            .padding(.top, 28.02)
+                            .padding(.bottom, 19)
                         }   // ~VStack
                     }
                     .padding(.top, 253)
                     .padding(.bottom, 173)
 
                 // Star
-                Image(systemName: "star.fill")   // Star1
+                Image("star_01")   // Star1
                     .resizable()
                     .scaledToFit()
                     .frame(width: 89, height: 86)
+                    .grayscale(scoreStar[0] ? 0.0 : 1.0)
                     .padding(EdgeInsets(top: 220, leading: 68, bottom: 538, trailing: 233))
-                Image(systemName: "star.fill")   // Star2
+                Image("star_01")   // Star2
                     .resizable()
                     .scaledToFit()
                     .frame(width: 89, height: 86)
+                    .grayscale(scoreStar[1] ? 0.0 : 1.0)
                     .padding(EdgeInsets(top: 187, leading: 153, bottom: 571, trailing: 148))
-                Image(systemName: "star")   // Star3
+                Image("star_01")   // Star3
                     .resizable()
                     .scaledToFit()
                     .frame(width: 89, height: 86)
+                    .grayscale(scoreStar[2] ? 0.0 : 1.0)
                     .padding(EdgeInsets(top: 220, leading: 238, bottom: 538, trailing: 63))
                 
                 

--- a/kini/kini/ReportView.swift
+++ b/kini/kini/ReportView.swift
@@ -25,11 +25,6 @@ struct ReportView: View {
     
     var body: some View {
             ZStack {
-                Color.gray010
-                    .blur(radius: 2)
-                    .animation(.easeInOut, value: 0.5)
-                    .ignoresSafeArea()
-                
                 Rectangle()  // Popup
                     .cornerRadius(15)
                     .frame(width: 350, height: 418)

--- a/kini/kini/TextModifier.swift
+++ b/kini/kini/TextModifier.swift
@@ -77,6 +77,15 @@ struct SRegularNavyTextModifier: ViewModifier {
     }
 }
 
+struct XSSemiboldNavyTextModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 13))
+            .fontWeight(.semibold)
+            .foregroundColor(Color.navy)
+    }
+}
+
 struct XSSemiboldBlackTextModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
@@ -118,7 +127,7 @@ struct XXSRegularGrayTextModifier: ViewModifier {
         content
             .font(.system(size: 12))
             .fontWeight(.regular)
-            .foregroundColor(Color(red: 0.235, green: 0.235, blue: 0.263)) //#3C3C43
+            .foregroundColor(Color.gray020)
             .opacity(0.61)
     }
 }


### PR DESCRIPTION
- [x] TextModifier, ButtonModifier, Color Extension Assets 사용
- [x] Color Extension에 회색계열 추가
   <img width="76" alt="image" src="https://github.com/Hola-Cosette/kini/assets/127754551/b9b927d7-c679-4523-b01d-724f228bb3a9">
  - gray010: 팝업 시 배경 블러 색
  - gray020: HistoryView에서 음식군 text color
  - gray030: FeedBackView에서 NavigationBar 영역 border
- [x] TextModifier에 회색 색상 반영하여 XXSRegularGrayTextModifier 수정
  - Color(red: 0.235, green: 0.235, blue: 0.263) -> gray020
- [x] TextModifier에 누락된 XSSemiboldNavyTextModifier 추가
  - size: 13, weight: .semibold, color: Color.navy

- [x] [음식확인 뷰] 화면 레이아웃 수정
- [x] [영양점수 뷰] 화면 레이아웃 수정
- [x] [히스토리 뷰] 화면 레이아웃 수정